### PR TITLE
[SDK-166] Add deletion of unsaved draft avatar

### DIFF
--- a/Runtime/AvatarManager.cs
+++ b/Runtime/AvatarManager.cs
@@ -169,6 +169,21 @@ namespace ReadyPlayerMe.AvatarCreator
 
             return avatarId;
         }
+        
+        /// <summary>
+        /// This will delete the avatar draft which have not been saved. 
+        /// </summary>
+        public async void DeleteDraft()
+        {
+            try
+            {
+                await avatarAPIRequests.DeleteAvatarDraft(avatarId);
+            }
+            catch (Exception e)
+            {
+                OnError?.Invoke(e.Message);
+            }
+        }
 
         /// <summary>
         /// This will delete the avatar completely even from database. 

--- a/Runtime/WebRequests/AvatarAPIRequests.cs
+++ b/Runtime/WebRequests/AvatarAPIRequests.cs
@@ -15,6 +15,7 @@ namespace ReadyPlayerMe.AvatarCreator
         private const string RESPONSE_TYPE_PARAMETER = "responseType=glb";
         private const string COLOR_PARAMETERS = "colors?type=skin,beard,hair,eyebrow";
         private const string FETCH_AVATAR_PARAMETERS = "?select=id,partner&userId=";
+        private const string DRAFT_PARAMETER = "draft";
 
         private readonly AuthorizedRequest authorizedRequest;
         private readonly CancellationToken ctx;
@@ -159,12 +160,25 @@ namespace ReadyPlayerMe.AvatarCreator
             return response.Text;
         }
 
+        public async Task DeleteAvatarDraft(string avatarId)
+        {
+            var response = await authorizedRequest.SendRequest<Response>(
+                new RequestData
+                {
+                    Url = $"{Endpoints.AVATAR_API_V2}/{avatarId}/{DRAFT_PARAMETER}",
+                    Method = HttpMethod.DELETE,
+                },
+                ctx: ctx);
+
+            response.ThrowIfError();
+        }
+
         public async Task DeleteAvatar(string avatarId)
         {
             var response = await authorizedRequest.SendRequest<Response>(
                 new RequestData
                 {
-                    Url = $"{Endpoints.AVATAR_API_V1}/{avatarId}",
+                    Url = $"{Endpoints.AVATAR_API_V2}/{avatarId}",
                     Method = HttpMethod.DELETE,
                 },
                 ctx: ctx);

--- a/Samples~/Scenes/AvatarCreatorExample.unity
+++ b/Samples~/Scenes/AvatarCreatorExample.unity
@@ -13002,6 +13002,7 @@ MonoBehaviour:
   - {fileID: 78456335}
   - {fileID: 227468989}
   backButton: {fileID: 1540936656}
+  saveButton: {fileID: 854279430}
   loadingManager: {fileID: 1810997809}
   startingState: 3
   avatarCreatorData: {fileID: 11400000, guid: b641399742edb414380c1d690dbd37df, type: 2}

--- a/Samples~/Scripts/UI/AvatarCreatorStateMachine.cs
+++ b/Samples~/Scripts/UI/AvatarCreatorStateMachine.cs
@@ -11,6 +11,7 @@ namespace ReadyPlayerMe
     {
         [SerializeField] private List<State> states;
         [SerializeField] private Button backButton;
+        [SerializeField] private Button saveButton;
         [SerializeField] private LoadingManager loadingManager;
         [SerializeField] private StateType startingState;
         [SerializeField] public AvatarCreatorData avatarCreatorData;
@@ -73,6 +74,7 @@ namespace ReadyPlayerMe
         private void OnStateChanged(StateType current, StateType previous)
         {
             backButton.gameObject.SetActive(!CanShowBackButton(current));
+            saveButton.gameObject.SetActive(current == StateType.Editor);
 
             if (current == StateType.End)
             {

--- a/Samples~/Scripts/UI/AvatarCreatorStateMachine.cs
+++ b/Samples~/Scripts/UI/AvatarCreatorStateMachine.cs
@@ -32,7 +32,7 @@ namespace ReadyPlayerMe
             AuthManager.OnSignedIn += OnSignedIn;
             AuthManager.OnSignedOut += OnSignedOut;
             AuthManager.OnSessionRefreshed += OnSessionRefreshed;
-            backButton.onClick.AddListener(Back);
+            backButton.onClick.AddListener(GoToPreviousState);
         }
 
         private void OnDisable()
@@ -41,7 +41,7 @@ namespace ReadyPlayerMe
             AuthManager.OnSignedIn -= OnSignedIn;
             AuthManager.OnSignedOut -= OnSignedOut;
             AuthManager.OnSessionRefreshed -= OnSessionRefreshed;
-            backButton.onClick.RemoveListener(Back);
+            backButton.onClick.RemoveListener(GoToPreviousState);
         }
         
         private void OnSignedIn(UserSession userSession)

--- a/Samples~/Scripts/UI/SelectionScreens/AvatarCreatorSelection.cs
+++ b/Samples~/Scripts/UI/SelectionScreens/AvatarCreatorSelection.cs
@@ -258,7 +258,10 @@ namespace ReadyPlayerMe
 
         public void Dispose()
         {
+            partnerAssetManager.OnError -= OnErrorCallback;
             partnerAssetManager?.Dispose();
+
+            avatarManager.OnError -= OnErrorCallback;
             avatarManager?.Dispose();
         }
     }

--- a/Samples~/Scripts/UI/SelectionScreens/AvatarCreatorSelection.cs
+++ b/Samples~/Scripts/UI/SelectionScreens/AvatarCreatorSelection.cs
@@ -199,12 +199,15 @@ namespace ReadyPlayerMe
 
         private async void Save()
         {
-            accountCreationPopup.gameObject.SetActive(true);
+            LoadingManager.EnableLoading("Saving avatar...", LoadingManager.LoadingType.Popup);
+
             var startTime = Time.time;
             var avatarId = await avatarManager.Save();
             AvatarCreatorData.AvatarProperties.Id = avatarId;
             DebugPanel.AddLogWithDuration("Avatar saved", Time.time - startTime);
             StateMachine.SetState(StateType.End);
+          
+            LoadingManager.DisableLoading();
         }
 
         private Dictionary<AssetType, object> GetDefaultAssets()

--- a/Samples~/Scripts/UI/SelectionScreens/AvatarCreatorSelection.cs
+++ b/Samples~/Scripts/UI/SelectionScreens/AvatarCreatorSelection.cs
@@ -80,7 +80,8 @@ namespace ReadyPlayerMe
             {
                 Destroy(currentAvatar);
             }
-            saveButton.gameObject.SetActive(false);
+
+            avatarManager.DeleteDraft();
 
             Dispose();
             assetTypeUICreator.ResetUI();

--- a/Samples~/Scripts/UI/SelectionScreens/AvatarCreatorSelection.cs
+++ b/Samples~/Scripts/UI/SelectionScreens/AvatarCreatorSelection.cs
@@ -93,7 +93,7 @@ namespace ReadyPlayerMe
             partnerAssetManager.OnError -= OnErrorCallback;
 
             ctxSource?.Cancel();
-            StateMachine.Back();
+            StateMachine.GoToPreviousState();
             LoadingManager.EnableLoading(error, LoadingManager.LoadingType.Popup, false);
         }
 

--- a/Samples~/Scripts/UI/StateMachine/StateMachine.cs
+++ b/Samples~/Scripts/UI/StateMachine/StateMachine.cs
@@ -51,7 +51,7 @@ namespace ReadyPlayerMe
             previousStates.Clear();
         }
 
-        public void Back()
+        public void GoToPreviousState()
         {
             var previousState = currentState; 
 


### PR DESCRIPTION
## [SDK-166](https://ready-player-me.atlassian.net/browse/SDK-166)

## Changes

#### Added

- API for deletion of draft avatar
- Deletion of unsaved draft avatar when back button is clicked from avatar creator screen

#### Updated

- Fix signup popup coming even when signed in
- Fix error while signing up
- Fix error when going back from avatar creator screen to avatar selection screen

## How to Test

-  Sign In and select an existing avatar
-  Customise it  
-  Go back to avatar selection screen
-  Select the same avatar and customise it again
-  Observe that previous selection have not been signed

<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.
-   [ ] QA Testing is updated.

## QA Testing

-   Mention any useful test cases for this feature and add to QA Testing documentation.

## Details

-   If more details are necessary to support the description with images and videos add them here.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->





[SDK-166]: https://ready-player-me.atlassian.net/browse/SDK-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ