### PR TITLE
[SDK-220] Fix for camera not working in WebGL builds

### DIFF
--- a/Samples~/Scripts/UI/SelectionScreens/CameraPhotoSelection.cs
+++ b/Samples~/Scripts/UI/SelectionScreens/CameraPhotoSelection.cs
@@ -37,10 +37,12 @@ namespace ReadyPlayerMe
             rawImage.color = Color.white;
             foreach (var device in devices)
             {
+#if UNITY_EDITOR || !UNITY_WEBGL // WebGL builds do not support front facing camera
                 if (!device.isFrontFacing)
                 {
                     continue;
                 }
+#endif
                 
                 var size = rawImage.rectTransform.sizeDelta;
                 camTexture = new WebCamTexture(device.name, (int) size.x, (int) size.y);

--- a/Samples~/Scripts/UI/SelectionScreens/CameraPhotoSelection.cs
+++ b/Samples~/Scripts/UI/SelectionScreens/CameraPhotoSelection.cs
@@ -14,7 +14,7 @@ namespace ReadyPlayerMe
         public override StateType NextState => StateType.Editor;
 
         private WebCamTexture camTexture;
-        
+
         public override void ActivateState()
         {
             cameraButton.onClick.AddListener(OnCameraButton);
@@ -29,14 +29,20 @@ namespace ReadyPlayerMe
 
         private void OpenCamera()
         {
-            var devices = WebCamTexture.devices;
+            WebCamDevice[] devices = WebCamTexture.devices;
             if (devices.Length == 0)
             {
                 return;
             }
 
             rawImage.color = Color.white;
-            var webCamDevice = devices.FirstOrDefault((device) => device.isFrontFacing);
+
+            WebCamDevice webCamDevice = devices.FirstOrDefault(device => device.isFrontFacing);
+            if (webCamDevice.Equals(default(WebCamDevice)))
+            {
+                webCamDevice = devices[0];
+            }
+
             Vector2 size = rawImage.rectTransform.sizeDelta;
             camTexture = new WebCamTexture(webCamDevice.name, (int) size.x, (int) size.y);
             camTexture.Play();
@@ -65,11 +71,11 @@ namespace ReadyPlayerMe
             texture.Apply();
 
             var bytes = texture.EncodeToPNG();
-            
+
             AvatarCreatorData.AvatarProperties.Id = string.Empty;
             AvatarCreatorData.AvatarProperties.Base64Image = Convert.ToBase64String(bytes);
             AvatarCreatorData.IsExistingAvatar = false;
-            
+
             StateMachine.SetState(StateType.Editor);
         }
     }

--- a/Samples~/Scripts/UI/SelectionScreens/CameraPhotoSelection.cs
+++ b/Samples~/Scripts/UI/SelectionScreens/CameraPhotoSelection.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -35,22 +36,12 @@ namespace ReadyPlayerMe
             }
 
             rawImage.color = Color.white;
-            foreach (var device in devices)
-            {
-#if UNITY_EDITOR || !UNITY_WEBGL // WebGL builds do not support front facing camera
-                if (!device.isFrontFacing)
-                {
-                    continue;
-                }
-#endif
-                
-                var size = rawImage.rectTransform.sizeDelta;
-                camTexture = new WebCamTexture(device.name, (int) size.x, (int) size.y);
-                camTexture.Play();
-                rawImage.texture = camTexture;
-                rawImage.SizeToParent();
-                return;
-            }
+            var webCamDevice = devices.FirstOrDefault((device) => device.isFrontFacing);
+            Vector2 size = rawImage.rectTransform.sizeDelta;
+            camTexture = new WebCamTexture(webCamDevice.name, (int) size.x, (int) size.y);
+            camTexture.Play();
+            rawImage.texture = camTexture;
+            rawImage.SizeToParent();
         }
 
         private void CloseCamera()


### PR DESCRIPTION
<!-- Copy the TICKETID for this task from Monday and add it to the PR name in brackets -->
<!-- PR name should look like: [TICKETID] My Pull Request -->

<!-- Add link for the ticket here editing the TICKETID-->

## [TICKETID](https://ready-player-me.atlassian.net/browse/TICKETID)

## Description

-   This PR includes a fix for an issue that prevented the camera access and preview from working on WebGL builds

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->


<!-- Testability -->

## How to Test

-   Build and run in the Avatar Creator sample scene in Unity for WebGL platform. Or test here 
https://hhough.itch.io/webgl-test?secret=GE46IsmEEo5kGDbrz2026HLns
Run throw the process of taking a photo and confirm that the camera access and preview works. 
NOTE: there is an issue that happens after taking photo, but I believe this issue is caused by the Assets Endpoint CORS error. I tried temporarily disabling the request to Assets endpoint and then this error went away. 


<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->



