### PR TITLE
[SDK-301]  Add handling of expired refresh token

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Please visit the online documentation and join our public `discord` community.
 - [Ready Player Me WebView](https://github.com/readyplayerme/rpm-unity-sdk-webview) - v1.2.0
 - [glTFast](https://github.com/atteneder/glTFast) - v5.0.0
 
+## Supported Platforms
+- Windows/Mac/Linux Standalone
+- Android*
+- iOS*
+
 ## Quick Start
 
 The installation steps can be found [here.](Documentation~/QuickStart.md)
@@ -48,6 +53,6 @@ The documentation for customization can be found [here.](Documentation~/Customiz
 
 ## Note
 
-- Camera support is currently only available for PC using Unity’s webcam native API.
+- [*]Camera support is currently only available for PC using Unity’s webcam native API.
 - Unity does not have a native file picker, so we have discontinued support for this feature.
 - To add support for camera on other platforms and file picker, you will need to implement it yourself.

--- a/Runtime/AuthManager.cs
+++ b/Runtime/AuthManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using ReadyPlayerMe.Core;
+using UnityEngine;
 
 namespace ReadyPlayerMe.AvatarCreator
 {
@@ -65,7 +66,17 @@ namespace ReadyPlayerMe.AvatarCreator
 
         public static async Task RefreshToken()
         {
-            var newTokens = await AuthenticationRequests.RefreshToken(userSession.Token, userSession.RefreshToken);
+            (string, string) newTokens;
+            try
+            {
+                newTokens = await AuthenticationRequests.RefreshToken(userSession.Token, userSession.RefreshToken);
+            }
+            catch (Exception e)
+            {
+                Debug.Log("Refreshing token failed with error: " + e.Message);
+                throw;
+            }
+
             userSession.Token = newTokens.Item1;
             userSession.RefreshToken = newTokens.Item2;
             OnSessionRefreshed?.Invoke(userSession);

--- a/Runtime/Data/PartnerAssets.cs
+++ b/Runtime/Data/PartnerAssets.cs
@@ -16,7 +16,7 @@ namespace ReadyPlayerMe.AvatarCreator
         public LockedCategories[] LockedCategories;
     }
 
-    public struct LockedCategories
+    public class LockedCategories
     {
         public string Name;
         public KeyValuePair<string, string>[] CustomizationCategories;

--- a/Runtime/WebRequests/AuthenticationRequests.cs
+++ b/Runtime/WebRequests/AuthenticationRequests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using ReadyPlayerMe.Core;
@@ -91,7 +92,10 @@ namespace ReadyPlayerMe.AvatarCreator
                 { AuthConstants.REFRESH_TOKEN, refreshToken }
             });
 
-            var response = await webRequestDispatcher.SendRequest<Response>(url, HttpMethod.POST, headers, payload);
+            // var response = await webRequestDispatcher.SendRequest<Response>(url, HttpMethod.POST, headers, payload);
+            var response = new Response();
+            response.IsSuccess = false;
+            response.Text = "{\"type\":\"BadRequestError\",\"message\":\"refresh token: The refresh token was not found or expired\",\"status\":400}";
             response.ThrowIfError();
 
             var data = AuthDataConverter.ParseResponse(response.Text);

--- a/Runtime/WebRequests/AuthenticationRequests.cs
+++ b/Runtime/WebRequests/AuthenticationRequests.cs
@@ -92,10 +92,7 @@ namespace ReadyPlayerMe.AvatarCreator
                 { AuthConstants.REFRESH_TOKEN, refreshToken }
             });
 
-            // var response = await webRequestDispatcher.SendRequest<Response>(url, HttpMethod.POST, headers, payload);
-            var response = new Response();
-            response.IsSuccess = false;
-            response.Text = "{\"type\":\"BadRequestError\",\"message\":\"refresh token: The refresh token was not found or expired\",\"status\":400}";
+            var response = await webRequestDispatcher.SendRequest<Response>(url, HttpMethod.POST, headers, payload);
             response.ThrowIfError();
 
             var data = AuthDataConverter.ParseResponse(response.Text);

--- a/Runtime/WebRequests/AuthorizedRequest.cs
+++ b/Runtime/WebRequests/AuthorizedRequest.cs
@@ -21,7 +21,7 @@ namespace ReadyPlayerMe.AvatarCreator
         {
             var response = await Send<T>(requestData, ctx);
 
-            // if (response is { IsSuccess: false, ResponseCode: 401 })
+            if (response is { IsSuccess: false, ResponseCode: 401 })
             {
                 try
                 {

--- a/Runtime/WebRequests/AuthorizedRequest.cs
+++ b/Runtime/WebRequests/AuthorizedRequest.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using ReadyPlayerMe.Core;
@@ -20,9 +21,17 @@ namespace ReadyPlayerMe.AvatarCreator
         {
             var response = await Send<T>(requestData, ctx);
 
-            if (response is { IsSuccess: false, ResponseCode: 401 })
+            // if (response is { IsSuccess: false, ResponseCode: 401 })
             {
-                await RefreshTokens();
+                try
+                {
+                    await AuthManager.RefreshToken();
+                }
+                catch (Exception e)
+                {
+                    throw;
+                }
+                
                 response = await Send<T>(requestData, ctx);
             }
 
@@ -46,11 +55,6 @@ namespace ReadyPlayerMe.AvatarCreator
                 requestData.DownloadHandler,
                 ctx: ctx
             );
-        }
-
-        private async Task RefreshTokens()
-        {
-            await AuthManager.RefreshToken();
         }
     }
 }

--- a/Samples~.meta
+++ b/Samples~.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3db6c1698b893994fb9706d9ca5ff9d3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/Prefabs/LoadingManager.prefab
+++ b/Samples~/Prefabs/LoadingManager.prefab
@@ -106,12 +106,12 @@ RectTransform:
   - {fileID: 2780647040885866876}
   - {fileID: 2780647041582791578}
   - {fileID: 2780647039787881174}
-  m_Father: {fileID: 2780647040815105543}
-  m_RootOrder: 1
+  m_Father: {fileID: 2780647041542613008}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 200.97995, y: -82.76961}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0.000012353, y: 41.7}
   m_SizeDelta: {x: 200, y: 31.846405}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2780647039911371397
@@ -519,13 +519,13 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 2780647040815105543}
-  m_RootOrder: 0
+  m_Father: {fileID: 2780647041542613008}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 200.97995, y: -33.423203}
-  m_SizeDelta: {x: 402.2054, y: 66.8464}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -7.9348, y: 26.807583}
+  m_SizeDelta: {x: 340, y: 82.5475}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2780647040595438480
 CanvasRenderer:
@@ -560,88 +560,15 @@ MonoBehaviour:
     m_FontSize: 25
     m_FontStyle: 0
     m_BestFit: 1
-    m_MinSize: 0
+    m_MinSize: 15
     m_MaxSize: 25
-    m_Alignment: 4
+    m_Alignment: 7
     m_AlignByGeometry: 0
     m_RichText: 1
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: Updating your avatar
---- !u!1 &2780647040815105540
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2780647040815105543}
-  - component: {fileID: 2780647040815105561}
-  - component: {fileID: 2780647040815105542}
-  m_Layer: 5
-  m_Name: Panel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &2780647040815105543
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2780647040815105540}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 2780647040595438494}
-  - {fileID: 2780647039911371394}
-  m_Father: {fileID: 2780647041542613008}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.000061035156, y: -4.806198}
-  m_SizeDelta: {x: -100.000046, y: -51.9072}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &2780647040815105561
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2780647040815105540}
-  m_CullTransparentMesh: 1
---- !u!114 &2780647040815105542
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2780647040815105540}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Padding:
-    m_Left: 0
-    m_Right: 0
-    m_Top: 0
-    m_Bottom: 0
-  m_ChildAlignment: 4
-  m_Spacing: 0
-  m_ChildForceExpandWidth: 1
-  m_ChildForceExpandHeight: 1
-  m_ChildControlWidth: 0
-  m_ChildControlHeight: 0
-  m_ChildScaleWidth: 0
-  m_ChildScaleHeight: 0
-  m_ReverseArrangement: 0
 --- !u!1 &2780647040873736902
 GameObject:
   m_ObjectHideFlags: 0
@@ -1180,14 +1107,15 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 2780647040013436610}
-  - {fileID: 2780647040815105543}
+  - {fileID: 2780647040595438494}
+  - {fileID: 2780647039911371394}
   m_Father: {fileID: 2780647040583977443}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.36800003, y: 0.43055558}
-  m_AnchorMax: {x: 0.63100004, y: 0.57000005}
-  m_AnchoredPosition: {x: -0.5, y: -1}
-  m_SizeDelta: {x: -3, y: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -1.4229126, y: -0.68792343}
+  m_SizeDelta: {x: 482.4893, y: 156.6399}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2780647041542613010
 CanvasRenderer:

--- a/Samples~/Scripts/ProfileManager.cs
+++ b/Samples~/Scripts/ProfileManager.cs
@@ -25,12 +25,15 @@ namespace ReadyPlayerMe
 
         private void OnEnable()
         {
-            profileUI.SignedOut += OnSignOut;
+            profileUI.SignedOut += AuthManager.Logout;
+            AuthManager.OnSignedOut += DeleteSession;
         }
+
 
         private void OnDisable()
         {
-            profileUI.SignedOut -= OnSignOut;
+            profileUI.SignedOut -= AuthManager.Logout;
+            AuthManager.OnSignedOut -= DeleteSession;
         }
 
         public bool LoadSession()
@@ -39,7 +42,6 @@ namespace ReadyPlayerMe
             {
                 return false;
             }
-           
             var bytes = File.ReadAllBytes(filePath);
             var json = Encoding.UTF8.GetString(bytes);
             var userSession = JsonConvert.DeserializeObject<UserSession>(json);
@@ -65,14 +67,14 @@ namespace ReadyPlayerMe
                 char.ToUpperInvariant(userSession.Name[0]).ToString()
             );
         }
-
-        private void OnSignOut()
+        
+        private void DeleteSession()
         {
-            AuthManager.Logout();
             if (File.Exists(filePath))
             {
                 File.Delete(filePath);
             }
+            profileUI.ClearProfile();
         }
 
     }

--- a/Samples~/Scripts/UI/AvatarCreatorStateMachine.cs
+++ b/Samples~/Scripts/UI/AvatarCreatorStateMachine.cs
@@ -53,7 +53,7 @@ namespace ReadyPlayerMe
         private void OnSignedOut()
         {
             avatarCreatorData.AvatarProperties.Id = string.Empty;
-            SetState(StateType.BodyTypeSelection);
+            SetState(startingState);
             ClearPreviousStates();
         }
         

--- a/Samples~/Scripts/UI/AvatarCreatorStateMachine.cs
+++ b/Samples~/Scripts/UI/AvatarCreatorStateMachine.cs
@@ -53,7 +53,7 @@ namespace ReadyPlayerMe
         private void OnSignedOut()
         {
             avatarCreatorData.AvatarProperties.Id = string.Empty;
-            SetState(StateType.LoginWithCodeFromEmail);
+            SetState(StateType.BodyTypeSelection);
             ClearPreviousStates();
         }
         

--- a/Samples~/Scripts/UI/ProfileUI.cs
+++ b/Samples~/Scripts/UI/ProfileUI.cs
@@ -32,10 +32,16 @@ namespace ReadyPlayerMe
             profileText.text = profileButtonText;
             profileButton.gameObject.SetActive(true);
         }
+        
+        public void ClearProfile()
+        {
+            username.text = string.Empty;
+            profileText.text = string.Empty;
+            profileButton.gameObject.SetActive(false);
+        }
 
         private void OnSignOutButton()
         {
-            profileButton.gameObject.SetActive(false);
             ToggleProfilePanel();
             SignedOut?.Invoke();
         }

--- a/Samples~/Scripts/UI/SelectionScreens/AvatarSelection.cs
+++ b/Samples~/Scripts/UI/SelectionScreens/AvatarSelection.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using ReadyPlayerMe.AvatarCreator;
 using UnityEngine;
@@ -47,7 +48,16 @@ namespace ReadyPlayerMe
             LoadingManager.EnableLoading();
 
             avatarAPIRequests = new AvatarAPIRequests();
-            avatarPartnerMap = await avatarAPIRequests.GetUserAvatars(AuthManager.UserSession.Id);
+            try
+            {
+                avatarPartnerMap = await avatarAPIRequests.GetUserAvatars(AuthManager.UserSession.Id);
+            }
+            catch (Exception e)
+            {
+                AuthManager.Logout();
+                LoadingManager.DisableLoading();
+                return;
+            }
 
             avatarButtonsMap = new Dictionary<string, GameObject>();
             foreach (var avatar in avatarPartnerMap)
@@ -83,6 +93,7 @@ namespace ReadyPlayerMe
 
         private void OnSignedOut()
         {
+            if (avatarButtonsMap == null) return;
             foreach (var avatars in avatarButtonsMap)
             {
                 Destroy(avatars.Value);


### PR DESCRIPTION
## [SDK-301](https://ready-player-me.atlassian.net/browse/SDK-301)

## Description

- Added handling of expired refresh token - logs out user if refresh token expires
- Fixed the blocking error on android #33 - fix found here https://github.com/jilleJr/Newtonsoft.Json-for-Unity/issues/77#issuecomment-766598863
- Updated readme with supported platform
- Adjusted loading popup ui according portrait mode

<!-- Fill the section below with Added, Updated and Removed information. -->
<!-- If there is no item under one of the lists remove it's title. -->

<!-- Testability -->

## How to Test

-  It can be tested by adding the mock code for refresh token expiry which can be seen in commit cd723e2bdbfde82934eb4d530a0c3eebce52f1b0
<!-- Update your progress with the task here -->

## Checklist

-   [ ] Tests written or updated for the changes.
-   [ ] Documentation is updated.
-   [ ] Changelog is updated.

<!--- Remember to copy the Changes Section into the commit message when you close the PR -->





[SDK-301]: https://ready-player-me.atlassian.net/browse/SDK-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ